### PR TITLE
refactor: removing the check if it's live or no in the debug method o…

### DIFF
--- a/lib/PayPal/Core/PayPalLoggingManager.php
+++ b/lib/PayPal/Core/PayPalLoggingManager.php
@@ -110,10 +110,6 @@ class PayPalLoggingManager
      */
     public function debug($message)
     {
-        $config = PayPalConfigManager::getInstance()->getConfigHashmap();
-        // Disable debug in live mode.
-        if (array_key_exists('mode', $config) && $config['mode'] != 'live') {
-            $this->logger->debug($message);
-        }
+        $this->logger->debug($message);
     }
 }


### PR DESCRIPTION
Removing the check if it's live or no in the debug method on PayPalLoggingManager.php

Doing this because there's already a configuration called `log.LogLevel` that takes care of checking this on Linio's side. We don't need this checked twice.

This is preventing us from debugging a current issue.